### PR TITLE
added max demand, timestamp and current demand. needs testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,18 @@ const object_patterns = {
     pattern   : /^1-0:71\.7\.0\(([0-9.]+)/m,
     transform : Number
   },
+  'current average demand' : {
+    pattern   : /^1-0:1\.4\.0\(([0-9.]+)/m,
+    transform : Number
+  },
+  'maximum demand timestamp' : {
+    pattern   : /^1-0:1\.6\.0\(([0-9.]+[WS])\)/m,
+    transform : utils.parseTimestamp
+  },
+  'maximum demand' : {
+    pattern   : /^1-0:1\.6\.0\([0-9.]+[WS]\)\(([0-9.]+)/m,
+    transform : Number
+  },
   'instantaneous active power L1 delivered' : {
     pattern   : /^1-0:21\.7\.0\(([0-9.]+)/m,
     transform : Number


### PR DESCRIPTION
In Belgium and the Capacity tariffs that was added on the 1st of January 2023, I have added the maximum demand for the current month, the timestamp that that has occurred, and maximum demand for the current period (15 minute period).